### PR TITLE
Fixed several bugs in read_settings function in metadata.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A decompiler for GHC-compiled Haskell
 To decompile a file without any installation steps, simply run the `runner.py` script on the file you want to decompile:
 
 ```
-python runner.py path/to/binary
+python3 runner.py path/to/binary
 ```
 
 ## Installation
@@ -19,7 +19,7 @@ python runner.py path/to/binary
 `hsdecomp` utilizes `setuptools` for packaging and installation. To install:
 
 ```
-python setup.py install
+python3 setup.py install
 ```
 
 ## Known Limitations

--- a/hsdecomp/metadata.py
+++ b/hsdecomp/metadata.py
@@ -48,15 +48,15 @@ def read_settings(opts):
         address_to_name = {},
         binary = open(opts.file, "rb").read(),
         capstone = capstone.Cs(capstone.CS_ARCH_X86, capstone_mode),
-        text_offset = elffile.get_section_by_name(b'.text')['sh_offset'] - elffile.get_section_by_name(b'.text')['sh_addr'],
-        data_offset = elffile.get_section_by_name(b'.data')['sh_offset'] - elffile.get_section_by_name(b'.data')['sh_addr'],
-        rodata_offset = elffile.get_section_by_name(b'.rodata')['sh_offset'] - elffile.get_section_by_name(b'.rodata')['sh_addr']
+        text_offset = elffile.get_section_by_name('.text')['sh_offset'] - elffile.get_section_by_name('.text')['sh_addr'],
+        data_offset = elffile.get_section_by_name('.data')['sh_offset'] - elffile.get_section_by_name('.data')['sh_addr'],
+        rodata_offset = elffile.get_section_by_name('.rodata')['sh_offset'] - elffile.get_section_by_name('.rodata')['sh_addr']
     )
 
-    symtab = elffile.get_section_by_name(b'.symtab')
+    symtab = elffile.get_section_by_name('.symtab')
     for sym in symtab.iter_symbols():
         try:
-            name = str(sym.name, 'ascii')
+            name = str(sym.name)
             offset = sym['st_value']
             settings.name_to_address[name] = offset
             settings.address_to_name[offset] = name


### PR DESCRIPTION
Hi, Thank you for making a nice tool.

However, when I executed testing hsdecomp, the following error occurred.
(I thought hsdecomp is a program for python3 because output is consists of tuples on python2)
``` 
$ python3 runner.py test/list/input
Traceback (most recent call last):
  File "runner.py", line 4, in <module>
    main()
  File "/home/junsoo/testing_hsdecomp/hsdecomp/hsdecomp/__init__.py", line 19, in main
    settings = metadata.read_settings(opts)
  File "/home/junsoo/testing_hsdecomp/hsdecomp/hsdecomp/metadata.py", line 51, in read_settings
    text_offset = elffile.get_section_by_name(b'.text')['sh_offset'] - elffile.get_section_by_name(b'.text')['sh_addr'],
TypeError: 'NoneType' object is not subscriptable
```
I found ```elffile.get_section_by_name(b'.text')``` on ```hsdecomp/metadata.py``` returns None because of prefix 'b'.
(I've referred to https://stackoverflow.com/questions/6269765/what-does-the-b-character-do-in-front-of-a-string-literal)

I fixed the problem and ran the program again. Now the following error occurred.
```
$ python3 runner.py test/list/input
Traceback (most recent call last):
  File "runner.py", line 4, in <module>
    main()
  File "/home/junsoo/testing_hsdecomp/hsdecomp/hsdecomp/__init__.py", line 23, in main
    entry_pointer = StaticValue(value = settings.name_to_address[opts.entry])
KeyError: 'Main_main_closure'
```
I found ```settings.name_to_address``` returns {}. And the related code is on ```hsdecomp/metadata.py```. 

See 59th line: ```name = str(sym.name, 'ascii')```
this line produces the following error (on try-except statement):
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: decoding str is not supported
```
So I rewrote that line as ```name = str(sym.name)```, and now I have found that all tests have the same value as the output.

Finally, I modified the readme for python3.