### PR TITLE
modify setup.py to correct installing hsdecomp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author = 'Jonathan S',
     author_email = 'gereeter+code@gmail.com',
     license = 'MIT',
-    packages = ['hsdecomp'],
+    packages = ['hsdecomp', 'hsdecomp.parse'],
     install_requires = [
         'pyelftools',
         'capstone'


### PR DESCRIPTION
Hi, Thank you for making a nice tool.

However, I get the following error when I try to run hsdecomp after installing it:
```
$ python3 setup.py install
...
Using /usr/local/lib/python3.5/dist-packages
Finished processing dependencies for hsdecomp==0.1.0
$
$ hsdecomp
Traceback (most recent call last):
  File "/usr/local/bin/hsdecomp", line 11, in <module>
    load_entry_point('hsdecomp==0.1.0', 'console_scripts', 'hsdecomp')()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 561, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.5/dist-packages/hsdecomp-0.1.0-py3.5.egg/hsdecomp/__init__.py", line 3, in <module>
  File "/usr/local/lib/python3.5/dist-packages/hsdecomp-0.1.0-py3.5.egg/hsdecomp/metadata.py", line 4, in <module>
ImportError: No module named 'hsdecomp.parse'
```

By debugging, I noticed that the contents of the parse folder inside the hsdecomp folder (subpackage) are not installed.

So I modified the code so that the package argument in the setup.py file contains the module 'hsdecomp.parse' like this:
```
Before:
packages = ['hsdecomp'],
After:
packages = ['hsdecomp', 'hsdecomp.parse'],
```

And i reinstalled hsdecomp and finally i can get hsdecomp.